### PR TITLE
fix: images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
       - persist_to_workspace:
           root: /root/project
           paths: 
-            - build
+            - ausguck
 
   deploy:
     docker:
@@ -35,7 +35,7 @@ jobs:
             git config user.name "ci-build"
       - run:
           name: Deploy build to gh-pages branch
-          command: gh-pages -x --dist build
+          command: gh-pages -x --dist ausguck
     
 workflows:
   version: 2

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 dist
 node_modules
-build/
+ausguck/

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ USAGE:
 npm run <start|build|pdf|image> <deckname>
 ```
 
+In order to let your images work locally: build all decks once: `./bin/create_decks` and start a server locally .i.e [http-server](https://www.npmjs.com/package/http-server).
+
 You can start the Currently available ones like this:
 
 ```sh

--- a/bin/create_decks
+++ b/bin/create_decks
@@ -13,14 +13,14 @@ function create_decks() {
 
         rm -Rf dist
         yarn build "$deck"
-        mkdir -p build/"$deck"
-        mv dist/* build/"$deck"/
+        mkdir -p ausguck/"$deck"
+        mv dist/* ausguck/"$deck"/
     done
     rm -Rf dist
 }
 
 function copy_images () {
-    cp -r decks/images build
+    cp -r decks/images ausguck
 }
 
 function create_index() {
@@ -35,7 +35,7 @@ function create_index() {
 
         printf "\n\n[farbenmeer.de](https://www.farbenmeer.de)"
 
-    } >> build/index.md
+    } >> ausguck/index.md
 }
 
 rm -Rf docs

--- a/decks/currying.mdx
+++ b/decks/currying.mdx
@@ -19,18 +19,18 @@ by Max Strübing
 
 ---
 
-![Haskell Curry](../images/currying/HaskellBCurry.jpg "Haskell Curry")  
+![Haskell Curry](/ausguck/images/currying/HaskellBCurry.jpg "Haskell Curry")  
 <small>Haskell Curry</small>
 
 ---
 
-![Function](../images/currying/function.svg "Function")
+![Function](/ausguck/images/currying/function.svg "Function")
 
 ---
 
-![Function](../images/currying/function.svg "Function")  
+![Function](/ausguck/images/currying/function.svg "Function")  
 
-![Curried Function](../images/currying/curriedFunction.svg "Curried Function")
+![Curried Function](/ausguck/images/currying/curriedFunction.svg "Curried Function")
 
 ---
 
@@ -87,7 +87,7 @@ const add = x => y => x + y;
 const add = (x, y) => x + y;
 ```
 
-![Function](../images/currying/function.svg "Function")  
+![Function](/ausguck/images/currying/function.svg "Function")  
 
 ---
 
@@ -95,7 +95,7 @@ const add = (x, y) => x + y;
 const add = x => y => x + y;
 ```
 
-![Curried Function](../images/currying/curriedFunction.svg "Curried Function")
+![Curried Function](/ausguck/images/currying/curriedFunction.svg "Curried Function")
 
 ---
 

--- a/decks/dynamic-programming.mdx
+++ b/decks/dynamic-programming.mdx
@@ -98,7 +98,7 @@ fib(4) + fib(3)
 
 ---
 
-![fibonacci 5 recursive](../images/dynamic-programming/fib5-recursive.png "fibonacci 5 recursive")
+![fibonacci 5 recursive](/ausguck/images/dynamic-programming/fib5-recursive.png "fibonacci 5 recursive")
 
 ---
 

--- a/decks/elm.mdx
+++ b/decks/elm.mdx
@@ -14,15 +14,15 @@ by Max Strübing
 
 ---
 
-![Elm logo](../images/elm/elm.png "Elm logo")
+![Elm logo](/ausguck/images/elm/elm.png "Elm logo")
 
 ---
 
-![Elm google search](../images/elm/elm-google.png "Elm google search")
+![Elm google search](/ausguck/images/elm/elm-google.png "Elm google search")
 
 ---
 
-![Elm google images search](../images/elm/elm-google-images.png "Elm google images search")
+![Elm google images search](/ausguck/images/elm/elm-google-images.png "Elm google images search")
 
 ---
 
@@ -30,11 +30,11 @@ by Max Strübing
 
 ---
 
-![undefined](../images/elm/undefined.png "undefined")
+![undefined](/ausguck/images/elm/undefined.png "undefined")
 
 ---
 
-![js parts](../images/elm/js-parts.jpg "js parts")
+![js parts](/ausguck/images/elm/js-parts.jpg "js parts")
 
 ---
 
@@ -46,7 +46,7 @@ Dan Abramov, Author of Redux
 
 ---
 
-![frontend dev](../images/elm/frontend.png "frontend dev")
+![frontend dev](/ausguck/images/elm/frontend.png "frontend dev")
 
 ---
 
@@ -65,7 +65,7 @@ Generate JavaScript with great performance and no runtime exceptions.
 
 ---
 
-![delightful](../images/elm/delightful.png "delightful")
+![delightful](/ausguck/images/elm/delightful.png "delightful")
 
 ---
 
@@ -103,7 +103,7 @@ Generate JavaScript with **great performance** and **no runtime exceptions** *.
 
 ---
 
-![boring](../images/elm/boring.webp "boring")
+![boring](/ausguck/images/elm/boring.webp "boring")
 
 ---
 
@@ -217,12 +217,12 @@ Generate JavaScript with **great performance** and **no runtime exceptions** *.
 
 ---
 
-![survey results](../images/elm/survey-results.png "survey results")  
+![survey results](/ausguck/images/elm/survey-results.png "survey results")  
 <small>https://ashleynolan.co.uk/blog/frontend-tooling-survey-2018-results</small>
 
 ---
 
-![maintainable usable](../images/elm/maintainable-usable.png "maintainable usable")
+![maintainable usable](/ausguck/images/elm/maintainable-usable.png "maintainable usable")
 <small>http://guupa.com/elm-presentation/</small>
 
 ---
@@ -231,18 +231,18 @@ Generate JavaScript with **great performance** and **no runtime exceptions** *.
 
 ---
 
-![cool](../images/elm/cool.webp "cool")
+![cool](/ausguck/images/elm/cool.webp "cool")
 
 ---
 
 # Performance
-![performance](../images/elm/performance.png "performance")  
+![performance](/ausguck/images/elm/performance.png "performance")  
 <small>https://elm-lang.org/blog/blazing-fast-html-round-two</small>
 
 ---
 
 # Asset Size
-![Asset Size](../images/elm/asset-sizes.png "Asset Size")  
+![Asset Size](/ausguck/images/elm/asset-sizes.png "Asset Size")  
 <small>https://elm-lang.org/blog/small-assets-without-the-headache</small>
 
 
@@ -252,27 +252,27 @@ Generate JavaScript with **great performance** and **no runtime exceptions** *.
 
 ---
 
-![list.nap](../images/elm/compiler-list-nap.png "list.nap")  
+![list.nap](/ausguck/images/elm/compiler-list-nap.png "list.nap")  
 
 ---
 
-![branches](../images/elm/compiler-branches.png "branches")  
+![branches](/ausguck/images/elm/compiler-branches.png "branches")  
 
 ---
 
-![type-comparisons](../images/elm/compiler-type-comparison.png "type-comparisons")  
+![type-comparisons](/ausguck/images/elm/compiler-type-comparison.png "type-comparisons")  
 
 ---
 
-![type-comparisons2](../images/elm/compiler-type-comparison2.png "type-comparisons2")  
+![type-comparisons2](/ausguck/images/elm/compiler-type-comparison2.png "type-comparisons2")  
 
 ---
 
-![type-comparisons3](../images/elm/compiler-type-comparison3.png "type-comparisons3")  
+![type-comparisons3](/ausguck/images/elm/compiler-type-comparison3.png "type-comparisons3")  
 
 ---
 
-![type-comparisons4](../images/elm/compiler-type-comparison4.png "type-comparisons4")  
+![type-comparisons4](/ausguck/images/elm/compiler-type-comparison4.png "type-comparisons4")  
 
 ---
 
@@ -280,15 +280,15 @@ Generate JavaScript with **great performance** and **no runtime exceptions** *.
 
 ---
 
-![Exceptions](../images/elm/exception.png "Exceptions")  
+![Exceptions](/ausguck/images/elm/exception.png "Exceptions")  
 
 ---
 
-![Exceptions 2](../images/elm/exception2.png "Exceptions 2")  
+![Exceptions 2](/ausguck/images/elm/exception2.png "Exceptions 2")  
 
 ---
 
-![head](../images/elm/head.png "head")  
+![head](/ausguck/images/elm/head.png "head")  
 
 ---
 
@@ -306,12 +306,12 @@ Debug.crash "WHOOPS"
 
 ---
 
-![semver](../images/elm/semver.png "semver")  
+![semver](/ausguck/images/elm/semver.png "semver")  
 
 ---
 
 
-![publishing](../images/elm/publishing.png "publishing")  
+![publishing](/ausguck/images/elm/publishing.png "publishing")  
 
 ---
 
@@ -508,7 +508,7 @@ Elm.App.embed(node);
 
 ```js
 import Elm from 'react-elm-components'
-import { Todo } from '../dist/elm/todomvc.js'
+import { Todo } from '/ausguck/dist/elm/todomvc.js'
 
 function render() {
 	return <Elm src={Todo} />
@@ -527,7 +527,7 @@ https://github.com/halfzebra/create-elm-app
 
 ---
 
-![waiting](../images/elm/are-you-done.gif "waiting")
+![waiting](/ausguck/images/elm/are-you-done.gif "waiting")
 
 ---
 
@@ -539,23 +539,23 @@ But first, the Elm-Architecure
 
 ---
 
-![elm-architecure](../images/elm/elm-architecture.png "elm-architecure")
+![elm-architecure](/ausguck/images/elm/elm-architecture.png "elm-architecure")
 
 ---
 
-![elm-architecure-program](../images/elm/elm-architecture-program.png "elm-architecure-program")
+![elm-architecure-program](/ausguck/images/elm/elm-architecture-program.png "elm-architecure-program")
 
 ---
 
-![elm-architecure-comlete](../images/elm/elm-architecture-complete.png "elm-architecure-complete")
+![elm-architecure-comlete](/ausguck/images/elm/elm-architecture-complete.png "elm-architecure-complete")
 
 ---
 
-![subscription](../images/elm/subscription.png "subscription")
+![subscription](/ausguck/images/elm/subscription.png "subscription")
 
 ---
 
-![cmd](../images/elm/cmd.png "cmd")
+![cmd](/ausguck/images/elm/cmd.png "cmd")
 
 ---
 
@@ -597,11 +597,11 @@ app.ports.setTitle.subscribe(title => {
 
 ---
 
-![spellcheck](../images/elm/spellcheck.png "spellcheck")
+![spellcheck](/ausguck/images/elm/spellcheck.png "spellcheck")
 
 ---
 
-![spellcheck2](../images/elm/spellcheck2.png "spellcheck2")
+![spellcheck2](/ausguck/images/elm/spellcheck2.png "spellcheck2")
 
 ---
 

--- a/decks/git-commits-versioning.mdx
+++ b/decks/git-commits-versioning.mdx
@@ -94,7 +94,7 @@ Add age field to all premium users.
 
 # What we do now
 
-<img src="../images/git-commits-semver/donts.png" alt="donts" width="800" />
+<img src="/ausguck/images/git-commits-semver/donts.png" alt="donts" width="800" />
 
 ---
 
@@ -134,7 +134,7 @@ PATCH version when you make backwards-compatible bug fixes
 
 # Tooling
 
-<img src="../images/git-commits-semver/sematic-release-note.png" alt="examples" width="800" />
+<img src="/ausguck/images/git-commits-semver/sematic-release-note.png" alt="examples" width="800" />
 
 [semantic-release](https://github.com/semantic-release/semantic-release) generates release note and number on each master merge/pull
 

--- a/decks/higher-order-components.mdx
+++ b/decks/higher-order-components.mdx
@@ -131,7 +131,7 @@ class App extends Component {
 
 ---
 
-![example](../images/higher-order-components/example.png "example")  
+![example](/ausguck/images/higher-order-components/example.png "example")  
 
 ---
 
@@ -174,11 +174,11 @@ const enhanceWithBackgroundHover = Component => color => {
 
 ---
 
-![example22](../images/higher-order-components/example2-1.png "example")  
+![example22](/ausguck/images/higher-order-components/example2-1.png "example")  
 
 -----
 
-![example2](../images/higher-order-components/example2-2.png "example")  
+![example2](/ausguck/images/higher-order-components/example2-2.png "example")  
 
 ---
 


### PR DESCRIPTION
This fixes the images - but sadly this would result in not working
locally anymore :/

MDXDeck changed it's routing so every deck thinks it is in the
basePath /

(no relative paths, but locally we don't have this `ausguck` part)

/cc @Kampfheizung 