### PR TITLE
fix: Add circleci config to build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,9 @@ jobs:
       - run:
           name: Build pages
           command: bin/create_decks 
+      - run:
+          name: Place circleci config
+          command: mkdir ausguck/.circleci && cp .circleci/config.yml ausguck/.circleci/config.yml
       - persist_to_workspace:
           root: /root/project
           paths: 


### PR DESCRIPTION
This should prevent circleCi to execute the test in the ignored branch 'gh-pages'

E.g.: https://circleci.com/gh/farbenmeer/ausguck/285 